### PR TITLE
[Site] Adjust branding to match designs - #22

### DIFF
--- a/site/src/components/Branding.js
+++ b/site/src/components/Branding.js
@@ -10,15 +10,12 @@ export default function Branding({tiny = false, dark = false, large = false,slog
         ? ' large'
         : ''}`}
     >
-      <div className="top">
-        <Logo className="logo" />
-        <h4 className="name">Mannequin</h4>
+      <Logo className="logo" />
+      <span className="separator"></span>
+      <div className="right">
+        <h2 className="name">Mannequin</h2>
+          {slogan && <h4 className="slogan">A Component Theming Tool for the Web</h4>}
       </div>
-      {slogan && (
-        <h3 className="slogan">
-          <span>A Component Theming Tool for the Web</span>
-        </h3>
-      )}
     </div>
   )
 }

--- a/site/src/components/Branding.scss
+++ b/site/src/components/Branding.scss
@@ -2,39 +2,45 @@
 @import "../scss/init";
 
 // This mixin calculates the ratios of the logo, name, and slogan
-@mixin branding-layout($logo_h, $name_font_size, $divider_margin) {
-  $logo_ratio : 63/61;
-  $logo_w: $logo_h * $logo_ratio;
-  $name_line_height: $name_font_size * 1.15;
+@mixin branding-layout($logo_w, $name_font_size, $divider_margin) {
   .logo {
-    height: rem-calc($logo_h);
+    // Height is calculated at a ratio of 61/63.  Change this if the logo image changes
+    // dimensions.
+    $logo_h: (61/63) * $logo_w;
     width: rem-calc($logo_w);
-    margin-top: rem-calc(($name_line_height - $logo_h) / 2);
-    margin-bottom: rem-calc(($name_line_height - $logo_h) / 2);
+    height: rem-calc($logo_h);
+    // Logo should be vertically centered, relative to the name.
+    margin-top: rem-calc(($name_font_size - $logo_h) / 2 * .9);
   }
   .name {
     font-size: rem-calc($name_font_size);
-    line-height: rem-calc($name_line_height);
   }
-  .logo + .name:before {
-    height: rem-calc($logo_h);
-    margin: 0 rem-calc($divider_margin);
+  .separator {
+    // Separator should be 60% of the name font size.
+    height: rem-calc($name_font_size * .6);
+    // Separator should be vertically centered relative to the name.
+    $vmargin: rem-calc($name_font_size * .2);
+    // Separator should be have right margin as specified, left margin
+    // applied at a ratio of 42/39 of the right margin.
+    margin: $vmargin rem-calc($divider_margin) $vmargin rem-calc($divider_margin * 42/39);
+  }
+  .slogan {
+    margin-top: rem-calc(10);
+    // Shift the slogan left 6px when the name_font_size is 73px, and scale
+    // that margin accordingly at all other sizes.
+    margin-left: rem-calc((6 * $name_font_size / 73));
   }
 }
 
 .Branding {
-  @include xy-grid-container();
-
+  display: inline-flex;
   .name {
     font-family: $impact-font-family;
     font-weight: 700;
     text-transform: uppercase;
     color: white;
     margin-bottom: 0;
-
-    a {
-      color: inherit;
-    }
+    line-height: 1;
   }
   .logo {
     stroke: white;
@@ -49,8 +55,6 @@
   }
 
   .slogan {
-    display:block;
-    margin-top: rem-calc(12);
     font-size: rem-calc(12);
     color: inherit;
     font-weight: 300;
@@ -60,15 +64,11 @@
       background-color: #1B2126;
     }
   }
-  .top {
-    display: flex;
-    .logo, h1 {
-      flex: 0 0 auto;
-    }
+  .separator {
+    border-left: 1px dashed $blue-gray;
   }
 
-
-  @include branding-layout(51, 31, 20);
+  @include branding-layout(53, 31, 20);
   // Variations:
   &.dark {
     .logo {
@@ -80,11 +80,11 @@
     }
   }
   &.tiny {
-    @include branding-layout(28, 24, 10);
+    @include branding-layout(27, 24, 10);
   }
   &.large {
     @include breakpoint(large) {
-      @include branding-layout(61, 73, 40);
+      @include branding-layout(63, 73, 39);
     }
   }
 }


### PR DESCRIPTION
Connects to #22 and #27.  Implements a 60%-of-name separator between the logo and the name, and shifts the slogan right.

Large:
<img width="877" alt="screen shot 2017-09-29 at 9 19 22 am" src="https://user-images.githubusercontent.com/654407/31017954-55f95c6e-a4f8-11e7-9344-388d0df5b93e.png">

Small/Medium:
<img width="613" alt="screen shot 2017-09-29 at 9 19 11 am" src="https://user-images.githubusercontent.com/654407/31017945-4e58848a-a4f8-11e7-8625-0c06bcad6a00.png">

@romario-agc - Look good?