### PR TITLE
Adjust brand name size for small breakpoint. #58

### DIFF
--- a/site/src/components/Branding.scss
+++ b/site/src/components/Branding.scss
@@ -14,6 +14,9 @@
   }
   .name {
     font-size: rem-calc($name_font_size);
+    @include breakpoint(small) {
+      font-size: rem-calc($name_font_size * .85);
+    }
   }
   .separator {
     // Separator should be 60% of the name font size.


### PR DESCRIPTION
Connects to #58 
@rbayliss I thought 85% of the font size on small looks good, and fixes both the breakage and the overflow. Let me know what you think. 