### PR TITLE
(Core) Warning message when starting live development server with a config that has no extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - (Core) Version number should be displayed when running the console.
 - (Core) Better error messages for missing/broken config files - [#75](https://github.com/LastCallMedia/Mannequin/issues/75).
 - (Core) Add helpful tips for the server start command [#79](https://github.com/LastCallMedia/Mannequin/issues/79)
+- (Core) Warning message when starting live development server with a config that has no extensions - [#80](https://github.com/LastCallMedia/Mannequin/issues/80)
 
 ### Added
 - (Core) Docroot setting added to configuration using the `setDocroot` method on the `MannequinConfig` object.

--- a/src/Core/Console/Command/ChecksConfig.php
+++ b/src/Core/Console/Command/ChecksConfig.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Mannequin.
+ *
+ * (c) 2017 Last Call Media, Rob Bayliss <rob@lastcallmedia.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace LastCall\Mannequin\Core\Console\Command;
+
+use LastCall\Mannequin\Core\Config\ConfigInterface;
+
+/**
+ * Checks for common problems with the configuration.
+ */
+trait ChecksConfig
+{
+    /**
+     * Checks a configuration for possible problems, and returns an array of
+     * warnings describing the problems.
+     *
+     * @param \LastCall\Mannequin\Core\Config\ConfigInterface $config
+     *
+     * @return string[]
+     */
+    public function checkConfig(ConfigInterface $config): array
+    {
+        $warnings = [];
+        if (1 === count($config->getExtensions())) {
+            $warnings[] = 'This configuration does not have any extensions associated with it.  Without extensions, no components will appear in the user interface. See https://mannequin.io/extensions for more information.';
+        }
+
+        return $warnings;
+    }
+}

--- a/src/Core/Console/Command/StartCommand.php
+++ b/src/Core/Console/Command/StartCommand.php
@@ -23,6 +23,8 @@ use Symfony\Component\Process\ProcessBuilder;
 
 class StartCommand extends Command
 {
+    use ChecksConfig;
+
     private $debug;
 
     private $config;
@@ -140,7 +142,12 @@ class StartCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         $address = $this->validateAddress($input->getArgument('address'));
+        $warnings = $this->checkConfig($this->config, $io);
+        if ($warnings) {
+            $io->warning(array_merge(['There were possible problems found with your configuration:'], $warnings));
+        }
 
         $routerFile = realpath(__DIR__.'/../../Resources/router.php');
         $builder = $this->getProcessBuilder()
@@ -156,7 +163,6 @@ class StartCommand extends Command
 
         $process = $builder->getProcess();
 
-        $io = new SymfonyStyle($input, $output);
         $io->title('Starting Mannequin development server...');
         $io->text('Tips:');
         $tips = [


### PR DESCRIPTION
Fixes #80.