### PR TITLE
(Drupal) Add default variables to all Drupal templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Upcoming
 ### Added
-(Drupal) Add default variables as in template_preprocess().  
+- (Drupal) Add default variables as in template_preprocess().  
 
 ## 1.0.6
 ## 1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Upcoming
+### Added
+(Drupal) Add default variables as in template_preprocess().  
+
 ## 1.0.6
 ## 1.0.5
 ### Added

--- a/docs/extensions/drupal.md
+++ b/docs/extensions/drupal.md
@@ -12,6 +12,14 @@ This extension shares DNA with the [TwigExtension](../extensions/twig.md), but i
   * Dummy `url`, `path`, `file_link` render` functions
   * `link` and `file_url`, and `create_attribute` functions
   * `placeholder`, `drupal_escape`, `safe_join`, `without`, `clean_class`, `clean_id` filters
+* Default variables available to every template:
+  * `attributes`: An `Attribute` object.
+  * `title_attributes`: An `Attribute` object.
+  * `title_prefix`: An empty array
+  * `title_suffix`: An empty array.
+  * `db_is_active`: true
+  * `is_admin`: false
+  * `logged_in`: false
 * Additional expressions to use in Sample declarations:
   * `attributes` - Creates an attribute object.
 

--- a/src/Drupal/Component/DrupalTwigComponent.php
+++ b/src/Drupal/Component/DrupalTwigComponent.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: rbayliss
+ * Date: 11/8/17
+ * Time: 5:00 PM
+ */
+
+namespace LastCall\Mannequin\Drupal\Component;
+
+
+use LastCall\Mannequin\Twig\Component\TwigComponent;
+
+class DrupalTwigComponent extends TwigComponent
+{
+
+}

--- a/src/Drupal/Component/DrupalTwigComponent.php
+++ b/src/Drupal/Component/DrupalTwigComponent.php
@@ -1,17 +1,18 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: rbayliss
- * Date: 11/8/17
- * Time: 5:00 PM
+
+/*
+ * This file is part of Mannequin.
+ *
+ * (c) 2017 Last Call Media, Rob Bayliss <rob@lastcallmedia.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
  */
 
 namespace LastCall\Mannequin\Drupal\Component;
-
 
 use LastCall\Mannequin\Twig\Component\TwigComponent;
 
 class DrupalTwigComponent extends TwigComponent
 {
-
 }

--- a/src/Drupal/Discovery/DrupalTwigDiscovery.php
+++ b/src/Drupal/Discovery/DrupalTwigDiscovery.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: rbayliss
+ * Date: 11/8/17
+ * Time: 4:59 PM
+ */
+
+namespace LastCall\Mannequin\Drupal\Discovery;
+
+
+use LastCall\Mannequin\Drupal\Component\DrupalTwigComponent;
+use LastCall\Mannequin\Twig\Component\TwigComponent;
+use LastCall\Mannequin\Twig\Discovery\TwigDiscovery;
+
+/**
+ * Extends TwigDiscovery to create Drupal components.
+ */
+class DrupalTwigDiscovery extends TwigDiscovery
+{
+    public function createComponent(string $name, array $aliases, \Twig_Environment $twig): TwigComponent
+    {
+        return new DrupalTwigComponent($name, $aliases, $twig);
+    }
+
+}

--- a/src/Drupal/Discovery/DrupalTwigDiscovery.php
+++ b/src/Drupal/Discovery/DrupalTwigDiscovery.php
@@ -1,13 +1,15 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: rbayliss
- * Date: 11/8/17
- * Time: 4:59 PM
+
+/*
+ * This file is part of Mannequin.
+ *
+ * (c) 2017 Last Call Media, Rob Bayliss <rob@lastcallmedia.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
  */
 
 namespace LastCall\Mannequin\Drupal\Discovery;
-
 
 use LastCall\Mannequin\Drupal\Component\DrupalTwigComponent;
 use LastCall\Mannequin\Twig\Component\TwigComponent;
@@ -22,5 +24,4 @@ class DrupalTwigDiscovery extends TwigDiscovery
     {
         return new DrupalTwigComponent($name, $aliases, $twig);
     }
-
 }

--- a/src/Drupal/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension.php
@@ -47,7 +47,7 @@ class DrupalExtension extends AbstractTwigExtension implements ExpressionFunctio
         return [
             new DrupalTwigDiscovery(
                 $this->getDriver(), $this->getIterator()
-            )
+            ),
         ];
     }
 

--- a/src/Drupal/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension.php
@@ -14,10 +14,13 @@ namespace LastCall\Mannequin\Drupal;
 use Drupal\Core\Template\Attribute;
 use LastCall\Mannequin\Core\Extension\ExtensionInterface;
 use LastCall\Mannequin\Core\Mannequin;
+use LastCall\Mannequin\Drupal\Discovery\DrupalTwigDiscovery;
 use LastCall\Mannequin\Drupal\Driver\DrupalTwigDriver;
 use LastCall\Mannequin\Drupal\Drupal\MannequinExtensionDiscovery;
+use LastCall\Mannequin\Drupal\Subscriber\DefaultVariablesSubscriber;
 use LastCall\Mannequin\Twig\AbstractTwigExtension;
 use LastCall\Mannequin\Twig\Driver\TwigDriverInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
@@ -37,6 +40,21 @@ class DrupalExtension extends AbstractTwigExtension implements ExpressionFunctio
         $this->iterator = $config['finder'] ?: new \ArrayIterator([]);
         $this->drupalRoot = $config['drupal_root'] ?? getcwd();
         $this->twigOptions = $config['twig_options'] ?? [];
+    }
+
+    public function getDiscoverers(): array
+    {
+        return [
+            new DrupalTwigDiscovery(
+                $this->getDriver(), $this->getIterator()
+            )
+        ];
+    }
+
+    public function subscribe(EventDispatcherInterface $dispatcher)
+    {
+        parent::subscribe($dispatcher);
+        $dispatcher->addSubscriber(new DefaultVariablesSubscriber());
     }
 
     /**

--- a/src/Drupal/Subscriber/DefaultVariablesSubscriber.php
+++ b/src/Drupal/Subscriber/DefaultVariablesSubscriber.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Mannequin.
+ *
+ * (c) 2017 Last Call Media, Rob Bayliss <rob@lastcallmedia.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace LastCall\Mannequin\Drupal\Subscriber;
+
+use Drupal\Core\Template\Attribute;
+use LastCall\Mannequin\Core\Event\ComponentEvents;
+use LastCall\Mannequin\Core\Event\RenderEvent;
+use LastCall\Mannequin\Drupal\Component\DrupalTwigComponent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class DefaultVariablesSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            ComponentEvents::PRE_RENDER => ['addDefaultVariables']
+        ];
+    }
+
+    public function addDefaultVariables(RenderEvent $event)
+    {
+        if($event->getComponent() instanceof DrupalTwigComponent) {
+            $variables = $event->getVariables();
+            $variables += [
+                'attributes' => new Attribute(),
+                'title_attributes' => new Attribute(),
+                'content_attributes' => new Attribute(),
+                'title_prefix' => [],
+                'title_suffix' => [],
+                'db_is_active' => true,
+                'is_admin' => false,
+                'logged_in' => false,
+            ];
+            $event->setVariables($variables);
+        }
+    }
+}

--- a/src/Drupal/Subscriber/DefaultVariablesSubscriber.php
+++ b/src/Drupal/Subscriber/DefaultVariablesSubscriber.php
@@ -22,13 +22,13 @@ class DefaultVariablesSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ComponentEvents::PRE_RENDER => ['addDefaultVariables']
+            ComponentEvents::PRE_RENDER => ['addDefaultVariables'],
         ];
     }
 
     public function addDefaultVariables(RenderEvent $event)
     {
-        if($event->getComponent() instanceof DrupalTwigComponent) {
+        if ($event->getComponent() instanceof DrupalTwigComponent) {
             $variables = $event->getVariables();
             $variables += [
                 'attributes' => new Attribute(),

--- a/src/Drupal/Tests/DrupalExtensionTest.php
+++ b/src/Drupal/Tests/DrupalExtensionTest.php
@@ -15,6 +15,7 @@ use LastCall\Mannequin\Core\Extension\ExtensionInterface;
 use LastCall\Mannequin\Core\Tests\Extension\ExtensionTestCase;
 use LastCall\Mannequin\Drupal\Driver\DrupalTwigDriver;
 use LastCall\Mannequin\Drupal\DrupalExtension;
+use LastCall\Mannequin\Drupal\Subscriber\DefaultVariablesSubscriber;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -32,9 +33,9 @@ class DrupalExtensionTest extends ExtensionTestCase
 
     protected function getDispatcherProphecy(): ObjectProphecy
     {
-        // For right now, we don't really test subscribers, because the Drupal
-        // extension just uses the TwigExtension's subscribers.
         $dispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $dispatcher->addSubscriber(Argument::type(DefaultVariablesSubscriber::class))
+            ->shouldBeCalled();
         $dispatcher->addSubscriber(Argument::type(EventSubscriberInterface::class))
             ->shouldBeCalled();
 

--- a/src/Drupal/Tests/Subscriber/DefaultVariableSubscriberTest.php
+++ b/src/Drupal/Tests/Subscriber/DefaultVariableSubscriberTest.php
@@ -1,13 +1,15 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: rbayliss
- * Date: 11/8/17
- * Time: 5:08 PM
+
+/*
+ * This file is part of Mannequin.
+ *
+ * (c) 2017 Last Call Media, Rob Bayliss <rob@lastcallmedia.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
  */
 
 namespace LastCall\Mannequin\Drupal\Tests\Subscriber;
-
 
 use Drupal\Core\Template\Attribute;
 use LastCall\Mannequin\Core\Component\ComponentCollection;
@@ -25,7 +27,8 @@ class DefaultVariableSubscriberTest extends TestCase
 {
     use ComponentSubscriberTestTrait;
 
-    public function getTests() {
+    public function getTests()
+    {
         return [
             [
                 [],
@@ -39,7 +42,7 @@ class DefaultVariableSubscriberTest extends TestCase
                     'is_admin' => false,
                     'logged_in' => false,
                 ],
-                'Defaults should fill any variable that has not been set.'
+                'Defaults should fill any variable that has not been set.',
             ],
             [
                 [
@@ -63,14 +66,15 @@ class DefaultVariableSubscriberTest extends TestCase
                     'logged_in' => true,
                 ],
                 'Defaults should not override existing values.',
-            ]
+            ],
         ];
     }
 
     /**
      * @dataProvider getTests
      */
-    public function testSetsDefaultValues($input, $expected, $message) {
+    public function testSetsDefaultValues($input, $expected, $message)
+    {
         $collection = $this->prophesize(ComponentCollection::class);
         $component = $this->prophesize(DrupalTwigComponent::class);
         $sample = $this->prophesize(Sample::class);

--- a/src/Drupal/Tests/Subscriber/DefaultVariableSubscriberTest.php
+++ b/src/Drupal/Tests/Subscriber/DefaultVariableSubscriberTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: rbayliss
+ * Date: 11/8/17
+ * Time: 5:08 PM
+ */
+
+namespace LastCall\Mannequin\Drupal\Tests\Subscriber;
+
+
+use Drupal\Core\Template\Attribute;
+use LastCall\Mannequin\Core\Component\ComponentCollection;
+use LastCall\Mannequin\Core\Component\Sample;
+use LastCall\Mannequin\Core\Event\ComponentEvents;
+use LastCall\Mannequin\Core\Event\RenderEvent;
+use LastCall\Mannequin\Core\Rendered;
+use LastCall\Mannequin\Core\Tests\Subscriber\ComponentSubscriberTestTrait;
+use LastCall\Mannequin\Drupal\Component\DrupalTwigComponent;
+use LastCall\Mannequin\Drupal\Subscriber\DefaultVariablesSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class DefaultVariableSubscriberTest extends TestCase
+{
+    use ComponentSubscriberTestTrait;
+
+    public function getTests() {
+        return [
+            [
+                [],
+                [
+                    'attributes' => new Attribute(),
+                    'title_attributes' => new Attribute(),
+                    'content_attributes' => new Attribute(),
+                    'title_prefix' => [],
+                    'title_suffix' => [],
+                    'db_is_active' => true,
+                    'is_admin' => false,
+                    'logged_in' => false,
+                ],
+                'Defaults should fill any variable that has not been set.'
+            ],
+            [
+                [
+                    'attributes' => new Attribute(['foo' => 'bar']),
+                    'title_attributes' => new Attribute(['foo' => 'bar']),
+                    'content_attributes' => new Attribute(['foo' => 'bar']),
+                    'title_prefix' => ['foo'],
+                    'title_suffix' => ['foo'],
+                    'db_is_active' => false,
+                    'is_admin' => true,
+                    'logged_in' => true,
+                ],
+                [
+                    'attributes' => new Attribute(['foo' => 'bar']),
+                    'title_attributes' => new Attribute(['foo' => 'bar']),
+                    'content_attributes' => new Attribute(['foo' => 'bar']),
+                    'title_prefix' => ['foo'],
+                    'title_suffix' => ['foo'],
+                    'db_is_active' => false,
+                    'is_admin' => true,
+                    'logged_in' => true,
+                ],
+                'Defaults should not override existing values.',
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getTests
+     */
+    public function testSetsDefaultValues($input, $expected, $message) {
+        $collection = $this->prophesize(ComponentCollection::class);
+        $component = $this->prophesize(DrupalTwigComponent::class);
+        $sample = $this->prophesize(Sample::class);
+
+        $event = new RenderEvent(
+            $collection->reveal(),
+            $component->reveal(),
+            $sample->reveal(),
+            new Rendered()
+        );
+        $event->setVariables($input);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new DefaultVariablesSubscriber());
+        $dispatcher->dispatch(ComponentEvents::PRE_RENDER, $event);
+        $this->assertEquals($expected, $event->getVariables(), $message);
+    }
+}


### PR DESCRIPTION
Fixes #103.  Adds default variables (attributes, etc) to all templates discovered by the `DrupalExtension`.

To do:
- [ ] Docs review (is it obvious that this is happening)
- [ ] Concept review (does what we're doing even make sense)
- [ ] Code review (does the code work/is there a better way to do something)