### PR TITLE
[Drupal] Add fallback loader to handle unscoped twig lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Upcoming
+### Added
+- (Drupal) Add fallback Twig loader to emulate Drupal's handling of unscoped include/extend statements by looking for templates in a specified module/theme - [#88](https://github.com/LastCallMedia/Mannequin/issues/88)
+
 ## 1.0.6
 ## 1.0.5
 ### Added

--- a/src/Drupal/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension.php
@@ -30,6 +30,7 @@ class DrupalExtension extends AbstractTwigExtension implements ExpressionFunctio
     private $drupalRoot;
     private $twigOptions;
     private $twigNamespaces = [];
+    private $fallbackExtensions = ['stable'];
     private $driver;
 
     public function __construct(array $config = [])
@@ -69,6 +70,26 @@ class DrupalExtension extends AbstractTwigExtension implements ExpressionFunctio
     }
 
     /**
+     * Add a Drupal extension to use as a "fallback" when a twig name can't be resolved.
+     *
+     * This exists to emulate the Drupal theme registry loader, which loads
+     * unqualified import/extend statements from the registry.  Since we don't
+     * have a registry, we support loading those unqualified imports from
+     * specified themes/modules.  This allows you to emulate the template
+     * inheritance chain.
+     *
+     * @param string[] $moduleOrThemeName an array of module or theme names
+     *
+     * @return \LastCall\Mannequin\Core\Extension\ExtensionInterface
+     */
+    public function setFallbackExtensions(array $moduleOrThemeNames): ExtensionInterface
+    {
+        $this->fallbackExtensions = $moduleOrThemeNames;
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getTemplateFilenameIterator(): \Traversable
@@ -87,7 +108,8 @@ class DrupalExtension extends AbstractTwigExtension implements ExpressionFunctio
                 $this->drupalRoot,
                 $discovery,
                 $this->twigOptions,
-                $this->twigNamespaces
+                $this->twigNamespaces,
+                $this->fallbackExtensions
             );
             $this->driver->setCache(new \Twig_Cache_Filesystem($this->mannequin->getCacheDir().'/twig'));
         }

--- a/src/Drupal/Tests/Driver/DrupalTwigDriverTest.php
+++ b/src/Drupal/Tests/Driver/DrupalTwigDriverTest.php
@@ -65,4 +65,22 @@ class DrupalTwigDriverTest extends DriverTestCase
         $bar = new \SplFileInfo($this->getDrupalRoot().'/core/misc/bar');
         $this->assertEquals(['@foo/bar'], $mapper($bar));
     }
+
+    public function testUsesFilesystemLoader()
+    {
+        $discovery = new MannequinExtensionDiscovery($this->getDrupalRoot());
+        $driver = new DrupalTwigDriver($this->getDrupalRoot(), $discovery);
+        $loader = $driver->getTwig()->getLoader();
+        $this->assertInstanceOf(\Twig_Loader_Filesystem::class, $loader, 'Without fallback extensions specified, the filesystem loader should be used directly.');
+    }
+
+    public function testUsesFallbackLoaderWhenFallbacksAreSpecified()
+    {
+        $discovery = new MannequinExtensionDiscovery($this->getDrupalRoot());
+        $driver = new DrupalTwigDriver($this->getDrupalRoot(), $discovery, [], [], ['classy']);
+        /** @var \Twig_Loader_Chain $loader */
+        $loader = $driver->getTwig()->getLoader();
+        $this->assertInstanceOf(\Twig_Loader_Chain::class, $loader, 'With fallback extensions, a Chain loader should be used.');
+        $this->assertTrue($loader->exists('block.html.twig'));
+    }
 }

--- a/src/Drupal/Tests/DrupalExtensionTest.php
+++ b/src/Drupal/Tests/DrupalExtensionTest.php
@@ -68,7 +68,7 @@ class DrupalExtensionTest extends ExtensionTestCase
         $discovery = new MannequinExtensionDiscovery(self::getDrupalRoot(), $mannequin->getCache());
         $expected = new DrupalTwigDriver(self::getDrupalRoot(), $discovery, [], [
             'foo' => ['../Resources'],
-        ], []);
+        ], ['stable']);
         $expected->setCache(new \Twig_Cache_Filesystem(sys_get_temp_dir().'/mannequin-test/twig'));
         $extension->register($mannequin);
         $this->assertEquals(
@@ -80,7 +80,7 @@ class DrupalExtensionTest extends ExtensionTestCase
     public function testDriverGetsFallbackExtensions()
     {
         $extension = new ExposedDrupalExtension(['drupal_root' => self::getDrupalRoot()]);
-        $extension->addFallbackExtension('classy');
+        $extension->setFallbackExtensions(['classy']);
         $mannequin = $this->getMannequin();
         $extension->register($mannequin);
 

--- a/src/Drupal/Tests/DrupalExtensionTest.php
+++ b/src/Drupal/Tests/DrupalExtensionTest.php
@@ -68,9 +68,26 @@ class DrupalExtensionTest extends ExtensionTestCase
         $discovery = new MannequinExtensionDiscovery(self::getDrupalRoot(), $mannequin->getCache());
         $expected = new DrupalTwigDriver(self::getDrupalRoot(), $discovery, [], [
             'foo' => ['../Resources'],
-        ]);
+        ], []);
         $expected->setCache(new \Twig_Cache_Filesystem(sys_get_temp_dir().'/mannequin-test/twig'));
         $extension->register($mannequin);
+        $this->assertEquals(
+            $expected,
+            $extension->getTwigDriver()
+        );
+    }
+
+    public function testDriverGetsFallbackExtensions()
+    {
+        $extension = new ExposedDrupalExtension(['drupal_root' => self::getDrupalRoot()]);
+        $extension->addFallbackExtension('classy');
+        $mannequin = $this->getMannequin();
+        $extension->register($mannequin);
+
+        $discovery = new MannequinExtensionDiscovery(self::getDrupalRoot(), $mannequin->getCache());
+        $expected = new DrupalTwigDriver(self::getDrupalRoot(), $discovery, [], [], ['classy']);
+        $expected->setCache(new \Twig_Cache_Filesystem(sys_get_temp_dir().'/mannequin-test/twig'));
+
         $this->assertEquals(
             $expected,
             $extension->getTwigDriver()

--- a/src/Drupal/Tests/Twig/Loader/FallbackLoaderTest.php
+++ b/src/Drupal/Tests/Twig/Loader/FallbackLoaderTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of Mannequin.
+ *
+ * (c) 2017 Last Call Media, Rob Bayliss <rob@lastcallmedia.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace LastCall\Mannequin\Drupal\Tests\Twig\Loader;
+
+use LastCall\Mannequin\Drupal\Twig\Loader\FallbackLoader;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+class FallbackLoaderTest extends TestCase
+{
+    public function getRoot()
+    {
+        $stream = vfsStream::setup('root', null, [
+            'p1' => [
+                't1' => 't1.p1',
+                'd1' => [
+                    't2' => 't2.p1',
+                    'd2' => [
+                        't3' => 't3.p1',
+                    ],
+                ],
+            ],
+            'p2' => [
+                't1.p2',
+                'd1' => [
+                    't2' => 't2.p2',
+                    'd2' => [
+                        't3' => 't3.p2',
+                        't4' => 't4.p2',
+                    ],
+                ],
+            ],
+        ]);
+
+        return $stream;
+    }
+
+    public function getExistsTests()
+    {
+        return [
+            ['t1', true, 'Existing templates at the root should be checked'],
+            ['t2', true, 'Existing templates in nested directories should be checked'],
+            ['t3', true, 'Existing templates in deeply nested directories should be checked'],
+            ['d1/t2', false, 'Template paths that include a directory separator should not be checked'],
+        ];
+    }
+
+    /**
+     * @dataProvider getExistsTests
+     */
+    public function testExists($input, $expected, $message)
+    {
+        $stream = $this->getRoot();
+        $loader = new FallbackLoader([
+            $stream->getChild('p1')->url(),
+            $stream->getChild('p2')->url(),
+        ]);
+        $this->assertEquals($expected, $loader->exists($input), $message);
+    }
+
+    public function getSourceTests()
+    {
+        return [
+            ['t1', 't1.p1', 'Template should be resolved from the first path that matches'],
+            ['t4', 't4.p2', 'Should check all paths before returning false.'],
+        ];
+    }
+
+    /**
+     * @dataProvider getSourceTests
+     */
+    public function testSource($input, $expected, $message)
+    {
+        $stream = $this->getRoot();
+        $loader = new FallbackLoader([
+            $stream->getChild('p1')->url(),
+            $stream->getChild('p2')->url(),
+        ]);
+        $context = $loader->getSourceContext($input);
+        $this->assertEquals($expected, $context->getCode(), $message);
+    }
+}

--- a/src/Drupal/Twig/Loader/FallbackLoader.php
+++ b/src/Drupal/Twig/Loader/FallbackLoader.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of Mannequin.
+ *
+ * (c) 2017 Last Call Media, Rob Bayliss <rob@lastcallmedia.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace LastCall\Mannequin\Drupal\Twig\Loader;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * This loader searches for unqualified template names in specific directories.
+ *
+ * Recurses into subdirectories searching for templates.  This is intended
+ * to be a simplified simulation of Drupal's theme registry loader, which looks
+ * up template paths against the stored theme registry.
+ */
+class FallbackLoader extends \Twig_Loader_Filesystem
+{
+    private $protectedRoot;
+
+    public function __construct($paths = [], $rootPath = null)
+    {
+        parent::__construct($paths, $rootPath);
+        // Store $rootPath in a way we can access it.
+        $this->protectedRoot = $rootPath;
+    }
+
+    public function findTemplate($name, $throw = true)
+    {
+        $name = $this->normalizeName($name);
+
+        // Caching for found/not found.
+        if (isset($this->cache[$name])) {
+            return $throw->cache[$name];
+        }
+        if (isset($this->errorCache[$name])) {
+            if (!$throw) {
+                return false;
+            }
+
+            throw new \Twig_Error_Loader($this->errorCache[$name]);
+        }
+
+        // Skip processing for any names that include a directory separator or
+        // a namepace.
+        if (false === strpos($name, '/') && 0 !== strpos($name, '@')) {
+            $paths = array_map(function ($path) {
+                if (!$this->isAbsolute($path)) {
+                    $path = $this->protectedRoot.'/'.$path;
+                }
+
+                return $path;
+            }, $this->paths[$this::MAIN_NAMESPACE]);
+
+            $finder = Finder::create()
+                ->in($paths)
+                ->files()
+                ->name($name);
+
+            foreach ($finder as $file) {
+                return $this->cache[$name] = $file->getPathname();
+            }
+            $this->errorCache[$name] = sprintf('Unable to find template "%s" (looked into: %s).', $name, implode(', ', $this->paths[self::MAIN_NAMESPACE]));
+        } else {
+            $this->errorCache[$name] = sprintf('Unable to find template "%s".', $name);
+        }
+
+        if (!$throw) {
+            return false;
+        }
+        throw new \Twig_Error_Loader($throw->errorCache[$name]);
+    }
+
+    /**
+     * Local duplicate of Twig_Loader_Filesystem::isAbsolutePath().
+     */
+    private function isAbsolute($path)
+    {
+        return strspn($path, '/\\', 0, 1)
+            || (strlen($path) > 3 && ctype_alpha($path[0])
+                && ':' === substr($path, 1, 1)
+                && strspn($path, '/\\', 2, 1)
+            )
+            || null !== parse_url($path, PHP_URL_SCHEME)
+            ;
+    }
+}


### PR DESCRIPTION
This PR implements the changes suggested in #88.  It adds a method to the DrupalExtension to let you set a set of "fallback" extensions.  Unscoped Twig lookups (eg: `{% extends 'block.html.twig' %}` will cause these fallback extensions to be searched, and the first matching template to be used.  Out of the box, `stable` is set as the default fallback.

To do:
- [ ] Add documentation about this feature
- [ ] Concept review/sanity check
- [ ] Code review
