### PR TITLE
Some [basically outdated] hero and logo changes

### DIFF
--- a/site/src/components/Branding.js
+++ b/site/src/components/Branding.js
@@ -22,7 +22,6 @@ export default function Branding({
   return (
     <Wrap {...wrapProps}>
       <Logo className="logo" />
-      <span className="separator" />
       <div className="right">
         <h2 className="name">Mannequin</h2>
         {slogan && (

--- a/site/src/components/Branding.scss
+++ b/site/src/components/Branding.scss
@@ -1,48 +1,24 @@
-
 @import "../scss/init";
 
-// This mixin calculates the ratios of the logo, name, and slogan
-@mixin branding-layout($logo_w, $name_font_size, $divider_margin, $reduce_on_mobile: true) {
-  .logo {
-    // Height is calculated at a ratio of 61/63.  Change this if the logo image changes
-    // dimensions.
-    $logo_h: (61/63) * $logo_w;
-    width: rem-calc($logo_w);
-    height: rem-calc($logo_h);
-    // Logo should be vertically centered, relative to the name.
-    margin-top: rem-calc(($name_font_size - $logo_h) / 2 * .9);
-  }
-  .right {
-    // Separator should be have right margin as specified, left margin
-    // applied at a ratio of 42/39 of the right margin.
-    margin-left: rem-calc($divider_margin);
-    padding-left: rem-calc($divider_margin * 42/39);
-  }
-  .name {
-    @if($reduce_on_mobile) {
-      font-size: rem-calc($name_font_size * .85);
-      @include breakpoint(medium) {
-        font-size: rem-calc($name_font_size);
-      }
-    }
-    @else {
-      font-size: rem-calc($name_font_size);
-    }
-
-  }
-  .slogan {
-    margin-top: rem-calc(10);
-    // Shift the slogan left 6px when the name_font_size is 73px, and scale
-    // that margin accordingly at all other sizes.
-    margin-left: rem-calc((6 * $name_font_size / 73));
-  }
-}
+$logo_w: 100;
+$divider_margin: 39;
+$name_font_size: 79;
+$name_font_size_small: 40;
 
 .Branding {
-  display: inline-flex;
-  .right {
-    text-align: left;
-    border-left: 1px dashed $dashing-gray;
+  @include breakpoint(medium) {
+    display: inline-flex;
+    .right {
+      text-align: left;
+      border-left: 1px dashed $dashing-gray;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      // Separator should be have right margin as specified, left margin
+      // applied at a ratio of 42/39 of the right margin.
+      margin-left: rem-calc($divider_margin);
+      padding-left: rem-calc($divider_margin * 42/39);
+    }
   }
   .name {
     font-family: $impact-font-family;
@@ -50,9 +26,19 @@
     text-transform: uppercase;
     color: white;
     margin-bottom: 0;
-    line-height: 1;
+    font-size: rem-calc($name_font_size);
+    line-height: 0.7;
+    @include breakpoint(small only) {
+      margin: rem-calc(23) 0;
+      font-size: rem-calc($name_font_size_small);
+    }
   }
   .logo {
+    // Height is calculated at a ratio of 61/63.  Change this if the logo image changes
+    // dimensions.
+    $logo_h: (61/63) * $logo_w;
+    width: rem-calc($logo_w);
+    height: rem-calc($logo_h);
     stroke: white;
     fill: white;
   }
@@ -65,6 +51,10 @@
   }
 
   .slogan {
+    margin-top: rem-calc(10);
+    // Shift the slogan left 6px when the name_font_size is 73px, and scale
+    // that margin accordingly at all other sizes.
+    margin-left: rem-calc((6 * $name_font_size / 73));
     margin-bottom: 0;
     font-size: rem-calc(12);
     color: inherit;
@@ -76,7 +66,6 @@
     }
   }
 
-  @include branding-layout(53, 31, 20);
   // Variations:
   &.dark {
     .logo {
@@ -85,14 +74,6 @@
     }
     .name {
       color: $black;
-    }
-  }
-  &.tiny {
-    @include branding-layout(27, 24, 10, false);
-  }
-  &.large {
-    @include breakpoint(large) {
-      @include branding-layout(63, 73, 39);
     }
   }
 }

--- a/site/src/components/Branding.scss
+++ b/site/src/components/Branding.scss
@@ -12,6 +12,12 @@
     // Logo should be vertically centered, relative to the name.
     margin-top: rem-calc(($name_font_size - $logo_h) / 2 * .9);
   }
+  .right {
+    // Separator should be have right margin as specified, left margin
+    // applied at a ratio of 42/39 of the right margin.
+    margin-left: rem-calc($divider_margin);
+    padding-left: rem-calc($divider_margin * 42/39);
+  }
   .name {
     @if($reduce_on_mobile) {
       font-size: rem-calc($name_font_size * .85);
@@ -24,15 +30,6 @@
     }
 
   }
-  .separator {
-    // Separator should be 60% of the name font size.
-    height: rem-calc($name_font_size * .6);
-    // Separator should be vertically centered relative to the name.
-    $vmargin: rem-calc($name_font_size * .2);
-    // Separator should be have right margin as specified, left margin
-    // applied at a ratio of 42/39 of the right margin.
-    margin: $vmargin rem-calc($divider_margin) $vmargin rem-calc($divider_margin * 42/39);
-  }
   .slogan {
     margin-top: rem-calc(10);
     // Shift the slogan left 6px when the name_font_size is 73px, and scale
@@ -43,6 +40,10 @@
 
 .Branding {
   display: inline-flex;
+  .right {
+    text-align: left;
+    border-left: 1px dashed $dashing-gray;
+  }
   .name {
     font-family: $impact-font-family;
     font-weight: 700;
@@ -64,6 +65,7 @@
   }
 
   .slogan {
+    margin-bottom: 0;
     font-size: rem-calc(12);
     color: inherit;
     font-weight: 300;
@@ -72,9 +74,6 @@
     span {
       background-color: #1B2126;
     }
-  }
-  .separator {
-    border-left: 1px dashed $dashing-gray;
   }
 
   @include branding-layout(53, 31, 20);

--- a/site/src/components/HomeTopBar.scss
+++ b/site/src/components/HomeTopBar.scss
@@ -15,7 +15,7 @@
     font-size: rem-calc(10);
     line-height: rem-calc(12);
 
-    font-weight: 300;
+    font-weight: 700;
     letter-spacing: 1px;
     text-transform: uppercase;
     display: inline-block;

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -63,7 +63,7 @@ function HomepageHero() {
           thickness={20}
           duration={35}
           blur={2}
-          top="110%"
+          top="67%"
           left="0"
           bottom="0"
           opacity={0.45}
@@ -73,7 +73,7 @@ function HomepageHero() {
           thickness={11}
           duration={9}
           blur={2}
-          top="100%"
+          top="70%"
           right="6%"
           opacity={0.45}
         />
@@ -85,7 +85,7 @@ function HomepageHero() {
           thickness={13}
           duration={15}
           blur={6}
-          top="105%"
+          top="60%"
           left="4%"
           opacity={0.25}
         />
@@ -110,7 +110,7 @@ function HomepageHero() {
           left="15%"
           opacity={0.07}
         />
-        <BubbleCluster duration={15} left="40%" top="110%">
+        <BubbleCluster duration={15} left="40%" top="72%">
           <Bubble size={30} thickness={10} blur={5} opacity={0.07} />
           <Bubble size={40} thickness={13} blur={5} opacity={0.07} />
         </BubbleCluster>

--- a/site/src/scss/_homepage.scss
+++ b/site/src/scss/_homepage.scss
@@ -3,7 +3,7 @@
   color: $white;
 
   .HomepageTopBar {
-    position: relative;
+    position: absolute;
     z-index: 3;
   }
 }
@@ -26,14 +26,14 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 80vh;
+    height: 100vh;
     width: 100%;
   }
 
   .HomepageHero + .mouse-icon {
-    position: absolute;
+    position: relative;
     margin-left: -12px; /* Subtracting half it's width, so any positioning will be relative to it's center, not left edge*/
-    bottom: rem-calc(20);
+    top: rem-calc(-60);
     left: 50%;
   }
 

--- a/site/src/scss/_homepage.scss
+++ b/site/src/scss/_homepage.scss
@@ -63,7 +63,8 @@
 .HomepageHero {
   @include xy-grid-container();
   .inner {
-    width: 75%;
+    width: 100%;
+    max-width: 960px;
     margin: 0 auto;
     text-align: center;
   }
@@ -74,13 +75,14 @@
   ul.links {
     list-style:none;
     margin: 0;
-    @include xy-grid();
-    @include xy-grid-layout(1, li);
     @include breakpoint(medium) {
-      @include xy-grid-layout(2, li);
-    }
-    @include breakpoint(large) {
-      @include xy-grid-layout(3, li);
+      display: flex;
+      align-items: center;
+      li {
+        margin: 0 1.5625%;
+        width: 100%;
+        white-space: nowrap;
+      }
     }
     a {
       margin-left: auto;

--- a/site/src/scss/_homepage.scss
+++ b/site/src/scss/_homepage.scss
@@ -23,7 +23,11 @@
   }
 
   .HomepageHero {
-    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 80vh;
+    width: 100%;
   }
 
   .HomepageHero + .mouse-icon {
@@ -59,19 +63,12 @@
 .HomepageHero {
   @include xy-grid-container();
   .inner {
-    @include breakpoint(large) {
-      max-width: xy-cell-size(9);
-    }
+    width: 75%;
     margin: 0 auto;
-    @include breakpoint(large){
-      margin-left: xy-cell-size(1);
-    }
-
-
+    text-align: center;
   }
-  padding: rem-calc(200) 0 0;
   .Branding {
-    margin-bottom: rem-calc(20);
+    margin-bottom: rem-calc(46.5);
     @include grid-column-gutter();
   }
   ul.links {

--- a/site/src/scss/_init.scss
+++ b/site/src/scss/_init.scss
@@ -5,6 +5,13 @@
 @import "variables";
 @import "~foundation-sites/scss/foundation";
 
+$breakpoints: (
+  small: 0,
+  medium: 760px,
+  large: 1024px,
+  xlarge: 1200px,
+  xxlarge: 1440px,
+);
 
 @mixin dashing-hoverable {
   border: 1px dashed $dashing-gray;


### PR DESCRIPTION
So I think I've finished up issues #22, #27, and #110. Was able to do this while removing more code than I added.

This includes centering the hero and these two InVision documents:
Wide: https://invis.io/XACPZRCDZ#/257679773_Homepage_-_Wide
Thin: https://invis.io/XJCXBEJFZ#/247440622_Homepage_-_Thin

Two things of notes:

1) I've removed much of the SCSS mixin logic in branding.scss because there are now just two different modes for the hero: medium+ and small. There is 100px range where the last two letters of MANNEQUIN get cut off before it snaps to the small layout. Leaning toward just making the homepage switch to the small/mobile/thin layout a hundred pixels earlier, in part because the thin layout actually looks great on a tablet (the only place I think people would see the "IN" cut off) and because  of the 2nd thing…

2) I'm not sure if this even worth merging in because @romario-agc already has new designs and I can just switch over to implementing them rather than pushing this stuff live.