### PR TITLE
Branding consistency and hero centering

### DIFF
--- a/site/src/components/Branding.js
+++ b/site/src/components/Branding.js
@@ -22,7 +22,6 @@ export default function Branding({
   return (
     <Wrap {...wrapProps}>
       <Logo className="logo" />
-      <span className="separator" />
       <div className="right">
         <h2 className="name">Mannequin</h2>
         {slogan && (

--- a/site/src/components/Branding.scss
+++ b/site/src/components/Branding.scss
@@ -2,54 +2,88 @@
 @import "../scss/init";
 
 // This mixin calculates the ratios of the logo, name, and slogan
-@mixin branding-layout($logo_w, $name_font_size, $divider_margin, $reduce_on_mobile: true) {
+@mixin branding-layout($logo_w, $name_font_size, $divider_margin, $reduce_on_mobile: true, $allow_vertical: false) {
+  @if ($allow_vertical) {
+    @include breakpoint(small only) {
+      display: block;
+    }
+  }
   .logo {
     // Height is calculated at a ratio of 61/63.  Change this if the logo image changes
     // dimensions.
     $logo_h: (61/63) * $logo_w;
     width: rem-calc($logo_w);
     height: rem-calc($logo_h);
-    // Logo should be vertically centered, relative to the name.
-    margin-top: rem-calc(($name_font_size - $logo_h) / 2 * .9);
+    @if ($allow_vertical) {
+      @include breakpoint(small only) {
+        margin-bottom: rem-calc(23)
+      }
+    }
+  }
+  .right {
+    // Separator should be have right margin as specified, left margin
+    // applied at a ratio of 42/39 of the right margin.
+    margin-left: rem-calc($divider_margin);
+    padding-left: rem-calc($divider_margin * 42/39);
+    @if ($allow_vertical) {
+      flex-direction: column;
+      align-items: start;
+      @include breakpoint(small only) {
+        margin: 0;
+        padding: 0;
+        border: none;
+        align-items: center;
+      }
+    }
   }
   .name {
-    @if($reduce_on_mobile) {
+    @if ($reduce_on_mobile) {
       font-size: rem-calc($name_font_size * .85);
       @include breakpoint(medium) {
         font-size: rem-calc($name_font_size);
       }
-    }
-    @else {
+    } @else {
       font-size: rem-calc($name_font_size);
     }
-
-  }
-  .separator {
-    // Separator should be 60% of the name font size.
-    height: rem-calc($name_font_size * .6);
-    // Separator should be vertically centered relative to the name.
-    $vmargin: rem-calc($name_font_size * .2);
-    // Separator should be have right margin as specified, left margin
-    // applied at a ratio of 42/39 of the right margin.
-    margin: $vmargin rem-calc($divider_margin) $vmargin rem-calc($divider_margin * 42/39);
+    @if ($allow_vertical) {
+      @include breakpoint(small only) {
+        margin-bottom: rem-calc(23);
+        font-size: rem-calc(40);
+      }
+    }
   }
   .slogan {
     margin-top: rem-calc(10);
     // Shift the slogan left 6px when the name_font_size is 73px, and scale
     // that margin accordingly at all other sizes.
     margin-left: rem-calc((6 * $name_font_size / 73));
+    @if ($allow_vertical) {
+      @include breakpoint(small only) {
+        margin: 0 rem-calc(10);
+        font-size: rem-calc(10);
+        text-align: center;
+        line-height: 2;
+      }
+    }
   }
 }
 
 .Branding {
   display: inline-flex;
+  .right {
+    text-align: left;
+    border-left: 1px dashed $dashing-gray;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
   .name {
     font-family: $impact-font-family;
     font-weight: 700;
     text-transform: uppercase;
     color: white;
     margin-bottom: 0;
-    line-height: 1;
+    line-height: 0.7;
   }
   .logo {
     stroke: white;
@@ -62,22 +96,22 @@
     display:inline-block;
     vertical-align: middle;
   }
-
   .slogan {
+    margin-bottom: 0;
     font-size: rem-calc(12);
     color: inherit;
     font-weight: 300;
     letter-spacing: 5px;
     text-transform: uppercase;
+    line-height: 0.7;
     span {
       background-color: #1B2126;
     }
   }
-  .separator {
-    border-left: 1px dashed $dashing-gray;
-  }
 
-  @include branding-layout(53, 31, 20);
+  @include branding-layout( $logo_w: 53,
+                            $name_font_size: 31,
+                            $divider_margin: 20 );
   // Variations:
   &.dark {
     .logo {
@@ -89,11 +123,15 @@
     }
   }
   &.tiny {
-    @include branding-layout(27, 24, 10, false);
+    @include branding-layout( $logo_w: 27,
+                              $name_font_size: 24,
+                              $divider_margin: 10,
+                              $reduce_on_mobile: false);
   }
   &.large {
-    @include breakpoint(large) {
-      @include branding-layout(63, 73, 39);
-    }
+    @include branding-layout( $logo_w: 100,
+                              $name_font_size: 73,
+                              $divider_margin: 39,
+                              $allow_vertical: true);
   }
 }

--- a/site/src/components/HomeTopBar.scss
+++ b/site/src/components/HomeTopBar.scss
@@ -15,7 +15,7 @@
     font-size: rem-calc(10);
     line-height: rem-calc(12);
 
-    font-weight: 300;
+    font-weight: 700;
     letter-spacing: 1px;
     text-transform: uppercase;
     display: inline-block;

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -63,7 +63,7 @@ function HomepageHero() {
           thickness={20}
           duration={35}
           blur={2}
-          top="110%"
+          top="67%"
           left="0"
           bottom="0"
           opacity={0.45}
@@ -73,7 +73,7 @@ function HomepageHero() {
           thickness={11}
           duration={9}
           blur={2}
-          top="100%"
+          top="70%"
           right="6%"
           opacity={0.45}
         />
@@ -85,7 +85,7 @@ function HomepageHero() {
           thickness={13}
           duration={15}
           blur={6}
-          top="105%"
+          top="60%"
           left="4%"
           opacity={0.25}
         />
@@ -110,7 +110,7 @@ function HomepageHero() {
           left="15%"
           opacity={0.07}
         />
-        <BubbleCluster duration={15} left="40%" top="110%">
+        <BubbleCluster duration={15} left="40%" top="72%">
           <Bubble size={30} thickness={10} blur={5} opacity={0.07} />
           <Bubble size={40} thickness={13} blur={5} opacity={0.07} />
         </BubbleCluster>

--- a/site/src/scss/_homepage.scss
+++ b/site/src/scss/_homepage.scss
@@ -3,7 +3,7 @@
   color: $white;
 
   .HomepageTopBar {
-    position: relative;
+    position: absolute;
     z-index: 3;
   }
 }
@@ -23,13 +23,17 @@
   }
 
   .HomepageHero {
-    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    width: 100%;
   }
 
   .HomepageHero + .mouse-icon {
-    position: absolute;
+    position: relative;
     margin-left: -12px; /* Subtracting half it's width, so any positioning will be relative to it's center, not left edge*/
-    bottom: rem-calc(20);
+    top: rem-calc(-60);
     left: 50%;
   }
 
@@ -59,31 +63,29 @@
 .HomepageHero {
   @include xy-grid-container();
   .inner {
-    @include breakpoint(large) {
-      max-width: xy-cell-size(9);
-    }
+    width: 100%;
+    max-width: 960px;
     margin: 0 auto;
-    @include breakpoint(large){
-      margin-left: xy-cell-size(1);
-    }
-
-
+    text-align: center;
   }
-  padding: rem-calc(200) 0 0;
   .Branding {
-    margin-bottom: rem-calc(20);
+    margin-bottom: rem-calc(46.5);
     @include grid-column-gutter();
   }
   ul.links {
     list-style:none;
     margin: 0;
-    @include xy-grid();
-    @include xy-grid-layout(1, li);
-    @include breakpoint(medium) {
-      @include xy-grid-layout(2, li);
+    li {
+      margin: 0 4.53125%;
     }
-    @include breakpoint(large) {
-      @include xy-grid-layout(3, li);
+    @include breakpoint(medium) {
+      display: flex;
+      align-items: center;
+      li {
+        margin: 0 1.5625%;
+        width: 100%;
+        white-space: nowrap;
+      }
     }
     a {
       margin-left: auto;

--- a/site/src/scss/_init.scss
+++ b/site/src/scss/_init.scss
@@ -5,6 +5,13 @@
 @import "variables";
 @import "~foundation-sites/scss/foundation";
 
+$breakpoints: (
+  small: 0,
+  medium: 760px,
+  large: 1024px,
+  xlarge: 1200px,
+  xxlarge: 1440px,
+);
 
 @mixin dashing-hoverable {
   border: 1px dashed $dashing-gray;


### PR DESCRIPTION
Redo of #22 & #27 fixes now taking into account that `.Branding` isn’t just used in the homepage hero (but also in the footer, docs, etc.).  Includes change to “medium” breakpoint.