### PR TITLE
Allow HTML in descriptions for components

### DIFF
--- a/ui/src/components/ComponentInfo.css
+++ b/ui/src/components/ComponentInfo.css
@@ -65,7 +65,8 @@
       line-height: 1.875rem;
       font-weight: bold;
       color: #767676; }
-    .ComponentInfo .info p {
+    .ComponentInfo .info p,
+    .ComponentInfo .info .component-description {
       font-size: 0.875rem;
       line-height: 1.875rem; }
   .ComponentInfo .code {

--- a/ui/src/components/ComponentInfo.js
+++ b/ui/src/components/ComponentInfo.js
@@ -73,12 +73,17 @@ ComponentInfoInfo.defaultProps = {
   used: []
 };
 
-const ComponentInfoSection = ({ title, children }) => (
-  <section>
-    <h4>{title}</h4>
-    <p>{children}</p>
-  </section>
-);
+class ComponentInfoSection extends Component {
+  render() {
+    return (
+      <section>
+        <h4>{this.props.title}</h4>
+      <div className="component-description" dangerouslySetInnerHTML={ {__html: this.props.children} } />
+      </section>
+    );
+  }
+}
+
 ComponentInfoSection.propTypes = {
   title: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired

--- a/ui/src/components/ComponentInfo.scss
+++ b/ui/src/components/ComponentInfo.scss
@@ -37,7 +37,8 @@
       font-weight: bold;
       color: #767676;
     }
-    p {
+    p,
+    .component-description {
       font-size: rem-calc(14);
       line-height: rem-calc(30);
     }


### PR DESCRIPTION
It would be great to able to format descriptions of components a little bit. As it is today all text is just wrapped in a `<p>` tag and not even newlines are respected.

Here is a low-tech solution for allowing HTML formatting in the descriptions of components.

<img width="883" alt="image" src="https://user-images.githubusercontent.com/193283/44909749-ca561d00-ad20-11e8-9866-838faffd7fb5.png">
